### PR TITLE
refactor: Modified scaleform from "BINOCULARS" to "OBSERVATORY_SCOPE"

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -113,10 +113,22 @@ local function CreateTelescopeCamera(entity, data)
 
     SetExtraTimecycleModifier("telescope")
 
-    scaleform = RequestScaleformMovie("binoculars")
+    scaleform = RequestScaleformMovie("OBSERVATORY_SCOPE")
     while not HasScaleformMovieLoaded(scaleform) do
         Citizen.Wait(10)
     end
+    local xres,yres = GetActiveScreenResolution()
+    BeginScaleformMovieMethod(scaleform, "SET_DISPLAY_CONFIG")
+    ScaleformMovieMethodAddParamInt(xres)
+    ScaleformMovieMethodAddParamInt(yres)
+    ScaleformMovieMethodAddParamInt(5) --_safeTopPercent
+    ScaleformMovieMethodAddParamInt(5) --_safeBottomPercent
+    ScaleformMovieMethodAddParamInt(5) --_safeLeftPercent
+    ScaleformMovieMethodAddParamInt(5) --_safeRightPercent
+    ScaleformMovieMethodAddParamBool(GetIsWidescreen())
+    ScaleformMovieMethodAddParamBool(GetIsHidef())
+    ScaleformMovieMethodAddParamBool(false) --isAsian
+    EndScaleformMovieMethod()
 
     RenderScriptCams(camera, 0, 0, false, false)
 end
@@ -231,15 +243,16 @@ local function HandleMovement(maxVertical)
 end
 
 local function RenderTelescopeLense()
-    DrawScaleformMovie(scaleform, 0.69, 0.5, 1.0, 1.0, 255, 255, 255, 255)
-    DrawScaleformMovie(scaleform, 0.31, 0.5, 1.0, 1.0, 255, 255, 255, 255)
+    --DrawScaleformMovie(scaleform, 0.69, 0.5, 1.0, 1.0, 255, 255, 255, 255)
+    --DrawScaleformMovie(scaleform, 0.31, 0.5, 1.0, 1.0, 255, 255, 255, 255)
 
-    DrawRect(0.10, 0.5, 0.2, 1.0, 0, 0, 0, 255) -- Left side
-    DrawRect(0.90, 0.5, 0.2, 1.0, 0, 0, 0, 255) -- Right side
+    --DrawRect(0.10, 0.5, 0.2, 1.0, 0, 0, 0, 255) -- Left side
+    --DrawRect(0.90, 0.5, 0.2, 1.0, 0, 0, 0, 255) -- Right side
+    DrawScaleformMovieFullscreen(scaleform, 255, 255,255,255,0)
 end
 
 local function RenderBinocularLense()
-    DrawScaleformMovie(scaleform, 0.5, 0.5, 1.0, 1.0, 255, 255, 255, 255)
+    --DrawScaleformMovie(scaleform, 0.5, 0.5, 1.0, 1.0, 255, 255, 255, 255)
 end
 
 local function GetClosestTelescope()


### PR DESCRIPTION
Heyo, 

I saw that you couldn't find the scaleform for the telescope, so I added it for you. This *should* work regardless of player resolution (compatible with GTAV ofc).

Current Scope:
![currentScope](https://user-images.githubusercontent.com/64140178/148052247-b2ac5b75-87b6-4acb-a3ab-f0dd9cb89fac.PNG)

New Scope:
![newScope](https://user-images.githubusercontent.com/64140178/148052277-3538391a-2175-4f25-9075-8dbba942ae15.PNG)
